### PR TITLE
Updated github actions and added CI badge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI job status](https://github.com/cawolfkreo/rabia-nes/workflows/CI/badge.svg)
+
 # What is this?
 another NES emulator, this time using Rust!!
 


### PR DESCRIPTION
# Description
I wanted to have a cool status badge for the project. Since we have the CI gh action working already, well, I thought it was a good idea to add the badge! 

## Badge example
This is how I expect the badge to look:

![CI job status](https://github.com/cawolfkreo/rabia-nes/workflows/Rust/badge.svg)

~~fair warning, I expect the badge to say "CI" instead of "Rust" once the `rust.yml` file is updated in the main branch. We'll see!~~ Wait, apparently the job ran with this branch with the "CI" already so it should end up looking like this:


![CI job status](https://github.com/cawolfkreo/rabia-nes/workflows/CI/badge.svg)