### PR TITLE
updated the name of the crate in the TOML.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty-nes"
+name = "rabia-nes"
 version = "0.1.0"
 dependencies = [
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty-nes"
+name = "rabia-nes"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::process;
 
-use rusty_nes::Config;
+use rabia_nes::Config;
 
 fn main() {
     let config: Config = create_config();
 
-    let emulation_result = rusty_nes::run(config);
+    let emulation_result = rabia_nes::run(config);
 
     if let Err(e) = emulation_result {
         eprintln!("Emulation error triggered!!");


### PR DESCRIPTION
# Description

I had a different name for the project and honestly, I forgot about it. Today I noticed the old name was there. I believe there is another Rust project using "Rusty Nes" as it's name, so I'm updating the config files of the project to make things more clear and consistent (and avoid future problems).